### PR TITLE
Adds the possibility to use own requestId, to associate in the response event

### DIFF
--- a/lib/socket.dart
+++ b/lib/socket.dart
@@ -63,8 +63,10 @@ class CastSocket {
   }
 
   void sendMessage(String namespace, String sourceId, String destinationId, Map<String, dynamic> payload) {
-    payload['requestId'] = _requestId;
-    _requestId += 1;
+    if (payload['requestId'] == null) {
+      payload['requestId'] = _requestId;
+      _requestId += 1;
+    }
 
     CastMessage castMessage = CastMessage();
     castMessage.protocolVersion = CastMessage_ProtocolVersion.CASTV2_1_0;


### PR DESCRIPTION
Hi,

I would like to get the response event based on the requestId.

Currently, there is no way to get the generated requestId from CastSocket.

I think the best solution is provide a way to use my own requestId, do you agree?

Thank you